### PR TITLE
feat(survey): encrypt responses at rest

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -8,3 +8,5 @@ DATABASE_URL=postgresql://mse_radar:mse_radar@localhost:5432/mse_radar
 
 BETTER_AUTH_SECRET=w28jHK7syJoESSjjL2cQ18iYl4M97ck8
 BETTER_AUTH_URL=http://localhost:4321
+
+RESPONSE_ENCRYPTION_KEY=YjKXKOG9+vboYStao6kTbk0qXRKDSDIhYV6xfciSbSo=

--- a/.env.sample
+++ b/.env.sample
@@ -8,3 +8,9 @@ DATABASE_URL=postgresql://mse_radar:mse_radar@localhost:5432/mse_radar
 
 BETTER_AUTH_SECRET=g8D5cEZ0y8JvvVrRQB2pmi4aDDWk569V
 BETTER_AUTH_URL=http://localhost:4321
+
+# Survey response encryption key (32 random bytes, base64-encoded).
+# Generate: `openssl rand -base64 32`
+# Must be kept out of reach of database administrators — losing it makes all
+# existing survey responses unreadable; leaking it breaks at-rest encryption.
+RESPONSE_ENCRYPTION_KEY=

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ MSE Radar helps software development teams assess their engineering capabilities
 cd astro && npm install && cd ..
 
 # Set up environment
-cp .env.sample .env
+cp .env.sample .env.local
+# Generate the survey response encryption key (32 bytes, base64)
+echo "RESPONSE_ENCRYPTION_KEY=$(openssl rand -base64 32)" >> .env.local
 
 # Set up database
 deno task db:migrate

--- a/astro/.env.local
+++ b/astro/.env.local
@@ -6,3 +6,5 @@ DATABASE_URL=postgresql://mse_radar:mse_radar@localhost:5432/mse_radar
 
 BETTER_AUTH_SECRET=A5NxyTYV7Uhg4AyEHukdvnsMEQ92ObVV
 BETTER_AUTH_URL=http://localhost:4321
+
+RESPONSE_ENCRYPTION_KEY=R8V5Qa7rjLdORwCvPn0AwZnlmL/+O9hWi8uGYtb63uM=

--- a/astro/.env.sample
+++ b/astro/.env.sample
@@ -6,3 +6,7 @@ DATABASE_URL=postgresql://mse_radar:mse_radar@localhost:5432/mse_radar
 
 BETTER_AUTH_SECRET=tLBu3FaX8fO1vj21gDHcbuG4iuezcVBh
 BETTER_AUTH_URL=http://localhost:4321
+
+# Survey response encryption key — 32 random bytes, base64-encoded.
+# Generate: `openssl rand -base64 32`
+RESPONSE_ENCRYPTION_KEY=

--- a/astro/astro.config.mjs
+++ b/astro/astro.config.mjs
@@ -36,6 +36,7 @@ export default defineConfig({
       DATABASE_URL: envField.string({ context: 'server', access: 'secret', default: '' }),
       BETTER_AUTH_SECRET: envField.string({ context: 'server', access: 'secret' }),
       BETTER_AUTH_URL: envField.string({ context: 'server', access: 'secret' }),
+      RESPONSE_ENCRYPTION_KEY: envField.string({ context: 'server', access: 'secret' }),
     },
   },
 

--- a/astro/src/database/survey-run-repository.ts
+++ b/astro/src/database/survey-run-repository.ts
@@ -4,6 +4,7 @@ import {
   SurveyRunResponse,
 } from '@models/aggregates/survey-run.ts';
 import { query, transaction } from '@database/db.ts';
+import { getResponseCrypto } from '@lib/response-crypto.ts';
 
 export interface SurveyRunRepository {
   getAllByTeamId(teamId: string): Promise<SurveyRun[]>;
@@ -22,8 +23,8 @@ type SurveyRunRow = {
 type SurveyResponseRow = {
   id: string;
   respondent_id: string;
-  answer_values: (AnswerValue | null)[];
-  answer_comments: (string | null)[];
+  answer_values: Buffer;
+  answer_comments: Buffer;
 };
 
 export class PgSurveyRunRepository implements SurveyRunRepository {
@@ -68,9 +69,14 @@ WHERE survey_run_id = $1`,
       [surveyRunRow.id],
     );
 
+    const crypto = getResponseCrypto();
     const surveyResponses = responseRows.rows.map((row) => {
-      const answerValues: (AnswerValue | null)[] = row.answer_values ?? [];
-      const answerComments: (string | null)[] = row.answer_comments ?? [];
+      const answerValues = crypto.decryptJson<(AnswerValue | null)[]>(
+        row.answer_values,
+      );
+      const answerComments = crypto.decryptJson<(string | null)[]>(
+        row.answer_comments,
+      );
 
       const answers = answerValues.map((answerValue, index) => ({
         answerValue,
@@ -104,6 +110,7 @@ WHERE survey_run_id = $1`,
         ],
       );
 
+      const crypto = getResponseCrypto();
       for (const response of surveyRun.responses) {
         const answerValues = response.answers.map(
           (answer) => answer.answerValue,
@@ -120,8 +127,8 @@ ON CONFLICT(survey_run_id, respondent_id) DO UPDATE SET
             response.id,
             surveyRun.id,
             response.respondentId,
-            JSON.stringify(answerValues),
-            JSON.stringify(comments),
+            crypto.encryptJson(answerValues),
+            crypto.encryptJson(comments),
           ],
         );
       }

--- a/astro/src/lib/response-crypto.test.ts
+++ b/astro/src/lib/response-crypto.test.ts
@@ -1,0 +1,49 @@
+import { randomBytes } from 'node:crypto';
+import { expect, suite, test } from 'vitest';
+import { createResponseCrypto } from '@lib/response-crypto.ts';
+
+suite('response-crypto', () => {
+  const key = randomBytes(32);
+  const crypto = createResponseCrypto(key);
+
+  test('round-trips JSON values', () => {
+    const value = [1, 2, null, 7, 3];
+    const blob = crypto.encryptJson(value);
+    expect(crypto.decryptJson(blob)).toEqual(value);
+  });
+
+  test('round-trips comments including null', () => {
+    const value = ['hello', null, 'world'];
+    const blob = crypto.encryptJson(value);
+    expect(crypto.decryptJson(blob)).toEqual(value);
+  });
+
+  test('produces different ciphertexts for same plaintext (unique IV)', () => {
+    const value = [1, 2, 3];
+    const a = crypto.encryptJson(value);
+    const b = crypto.encryptJson(value);
+    expect(a.equals(b)).toBe(false);
+  });
+
+  test('ciphertext does not contain plaintext bytes', () => {
+    const value = [1, 7, 3];
+    const blob = crypto.encryptJson(value);
+    expect(blob.toString('utf8')).not.toContain('[1,7,3]');
+  });
+
+  test('rejects tampered ciphertext', () => {
+    const blob = crypto.encryptJson([1, 2, 3]);
+    blob[blob.length - 1] ^= 0x01;
+    expect(() => crypto.decryptJson(blob)).toThrow();
+  });
+
+  test('rejects wrong key', () => {
+    const blob = crypto.encryptJson([1, 2, 3]);
+    const other = createResponseCrypto(randomBytes(32));
+    expect(() => other.decryptJson(blob)).toThrow();
+  });
+
+  test('rejects non-32-byte key', () => {
+    expect(() => createResponseCrypto(randomBytes(16))).toThrow();
+  });
+});

--- a/astro/src/lib/response-crypto.ts
+++ b/astro/src/lib/response-crypto.ts
@@ -1,0 +1,57 @@
+import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto';
+import { RESPONSE_ENCRYPTION_KEY } from 'astro:env/server';
+
+const IV_LEN = 12;
+const TAG_LEN = 16;
+const KEY_LEN = 32;
+
+export interface ResponseCrypto {
+  encryptJson(value: unknown): Buffer;
+  decryptJson<T>(blob: Buffer): T;
+}
+
+export function createResponseCrypto(key: Buffer): ResponseCrypto {
+  if (key.length !== KEY_LEN) {
+    throw new Error(
+      `Response crypto key must be ${KEY_LEN} bytes, got ${key.length}`,
+    );
+  }
+  return {
+    encryptJson(value: unknown): Buffer {
+      const iv = randomBytes(IV_LEN);
+      const cipher = createCipheriv('aes-256-gcm', key, iv);
+      const plaintext = Buffer.from(JSON.stringify(value), 'utf8');
+      const ciphertext = Buffer.concat([
+        cipher.update(plaintext),
+        cipher.final(),
+      ]);
+      const tag = cipher.getAuthTag();
+      return Buffer.concat([iv, tag, ciphertext]);
+    },
+    decryptJson<T>(blob: Buffer): T {
+      const iv = blob.subarray(0, IV_LEN);
+      const tag = blob.subarray(IV_LEN, IV_LEN + TAG_LEN);
+      const ciphertext = blob.subarray(IV_LEN + TAG_LEN);
+      const decipher = createDecipheriv('aes-256-gcm', key, iv);
+      decipher.setAuthTag(tag);
+      const plaintext = Buffer.concat([
+        decipher.update(ciphertext),
+        decipher.final(),
+      ]);
+      return JSON.parse(plaintext.toString('utf8')) as T;
+    },
+  };
+}
+
+let defaultInstance: ResponseCrypto | undefined;
+
+export function getResponseCrypto(): ResponseCrypto {
+  if (!defaultInstance) {
+    if (!RESPONSE_ENCRYPTION_KEY) {
+      throw new Error('RESPONSE_ENCRYPTION_KEY is not set');
+    }
+    const key = Buffer.from(RESPONSE_ENCRYPTION_KEY, 'base64');
+    defaultInstance = createResponseCrypto(key);
+  }
+  return defaultInstance;
+}

--- a/db/migrations/001_schema.sql
+++ b/db/migrations/001_schema.sql
@@ -71,13 +71,17 @@ CREATE INDEX idx_survey_runs_team_id ON survey_runs(team_id);
 CREATE INDEX idx_survey_runs_survey_model_id ON survey_runs(survey_model_id);
 CREATE INDEX idx_survey_runs_status ON survey_runs(status);
 
+-- answer_values / answer_comments: AES-256-GCM ciphertext
+-- (iv(12) || tag(16) || ciphertext) of the JSON-encoded answer arrays.
+-- Encryption key held by application (RESPONSE_ENCRYPTION_KEY).
+-- See docs/agents/architecture.md → Encryption at rest.
 CREATE TABLE survey_responses (
   id UUID PRIMARY KEY,
   survey_run_id UUID NOT NULL REFERENCES survey_runs(id),
   respondent_id UUID NOT NULL REFERENCES users(id),
   submitted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  answer_values JSONB NOT NULL DEFAULT '[]'::jsonb,
-  answer_comments JSONB NOT NULL DEFAULT '[]'::jsonb,
+  answer_values BYTEA NOT NULL,
+  answer_comments BYTEA NOT NULL,
   UNIQUE(survey_run_id, respondent_id)
 );
 

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -19,8 +19,18 @@
 
 ## Database Design
 
-- PostgreSQL with JSONB arrays for answer values
+- PostgreSQL; `survey_responses.answer_values` and `answer_comments` stored as BYTEA ciphertext (see Encryption at rest below)
 - Last-write-wins strategy for multiple submissions
+
+## Encryption at rest
+
+Survey response values and comments are encrypted with AES-256-GCM before insert/update and decrypted on load.
+
+- Key: `RESPONSE_ENCRYPTION_KEY` env var, 32 bytes base64-encoded
+- Threat model: **database administrators** (Postgres/backup access) — they see ciphertext only, cannot learn who rated which capability. The application operator is trusted.
+- `respondent_id` stays plaintext — participation is not private, only rating values are.
+- Out of scope: key rotation (future: versioned key ID column), hardware-backed key storage (KMS/Vault).
+- Losing the key makes all existing responses unreadable; leaking it to someone with DB access breaks the guarantee.
 
 ## Reference Documentation
 

--- a/docs/bounded_contexts.md
+++ b/docs/bounded_contexts.md
@@ -289,6 +289,7 @@ Manages the lifecycle of survey runs, collecting responses from team members, an
 - A survey run can be reopened after being closed
 - Respondent identifiers are protected (only accessible to authorized system components)
 - Raw responses are only visible to the submitter
+- Rating values and comments are encrypted at rest
 
 ---
 

--- a/docs/database-diagram.md
+++ b/docs/database-diagram.md
@@ -62,8 +62,8 @@ erDiagram
         UUID survey_run_id FK
         UUID respondent_id FK
         TIMESTAMPTZ submitted_at
-        JSONB answer_values
-        JSONB answer_comments
+        BYTEA answer_values
+        BYTEA answer_comments
     }
 
     users ||--o{ team_memberships : "has"

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -71,6 +71,7 @@
 - Team leads are also team members. They can answer surveys for their team.
 - Raw individual responses are only ever visible to the team members who submitted them. No team member or team lead can see the raw responses of another team member.
 - Pseudonymity: No one can see who answered what. (Exception: respondents can see their own responses) Responses will be aggregated.
+- Encryption at rest: rating values and comments should be encrypted with an app-held key.
 - "Audit context" requires storing identifiers that could re-identify people. These identifiers should be protected and only accessible to authorized system components.
 - DORA capabilities are defined in https://dora.dev/capabilities/.
 - Survey questions should be defined as a Likert Scale (1-7)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Survey response data (ratings and comments) now encrypted at rest using AES-256-GCM encryption for improved data protection and privacy.

* **Documentation**
  * Updated database schema and architecture documentation to reflect encryption implementation and configuration requirements.

* **Tests**
  * Added comprehensive test suite for encryption and decryption functionality, including edge cases and security validations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->