### PR TITLE
test(acceptance): enable parallel execution via token-based namespacing

### DIFF
--- a/acceptance/dsl/Dsl.ts
+++ b/acceptance/dsl/Dsl.ts
@@ -23,7 +23,7 @@ export class Dsl {
     await this.browser?.close();
   }
 
-  async setUp(sut: AstroSutHandle) {
+  async setUp(sut: AstroSutHandle, token: string) {
     if (!this.browser) {
       throw new Error('Browser not set up. Call setUpBrowser() first.');
     }
@@ -33,10 +33,10 @@ export class Dsl {
     const page = await this.context.newPage();
     await page.goto('/');
     const driver = new ProtocolDriver(page);
-    this.identityAndAccess = new IdentityAndAccessDsl(driver);
-    this.teamManagement = new TeamManagementDsl(driver);
+    this.identityAndAccess = new IdentityAndAccessDsl(driver, token);
+    this.teamManagement = new TeamManagementDsl(driver, token);
     this.surveyDefinition = new SurveyDefinitionDsl(driver);
-    this.surveyExecution = new SurveyExecutionDsl(driver);
+    this.surveyExecution = new SurveyExecutionDsl(driver, token);
   }
 
   async tearDown() {

--- a/acceptance/dsl/IdentityAndAccessDsl.ts
+++ b/acceptance/dsl/IdentityAndAccessDsl.ts
@@ -1,4 +1,5 @@
 import { ProtocolDriver } from '../drivers/ProtocolDriver.ts';
+import { namespaceEmail } from './testNamespace.ts';
 
 export type RegisterUserParams = {
   email?: string;
@@ -18,12 +19,19 @@ const DEFAULT_DUMMY_EMAIL = 'clara@example.com';
 const DEFAULT_DUMMY_PASSWORD = 'password123';
 
 export class IdentityAndAccessDsl {
-  constructor(private readonly driver: ProtocolDriver) {
+  constructor(
+    private readonly driver: ProtocolDriver,
+    private readonly token: string,
+  ) {
+  }
+
+  private email(email: string): string {
+    return namespaceEmail(email, this.token);
   }
 
   async registerUser(params?: RegisterUserParams) {
     await this.driver.openUserRegistrationPage();
-    const email = params?.email ?? DEFAULT_DUMMY_EMAIL;
+    const email = this.email(params?.email ?? DEFAULT_DUMMY_EMAIL);
     const password = params?.password ?? DEFAULT_DUMMY_PASSWORD;
     await this.driver.registerUser(email, password);
   }
@@ -43,13 +51,13 @@ export class IdentityAndAccessDsl {
   async signIn(params?: SignInParams) {
     await this.driver.openLoginPage();
 
-    const email = params?.email ?? DEFAULT_DUMMY_EMAIL;
+    const email = this.email(params?.email ?? DEFAULT_DUMMY_EMAIL);
     const password = params?.password ?? DEFAULT_DUMMY_PASSWORD;
     await this.driver.loginUser(email, password);
   }
 
   async confirmSuccessfulSignIn(params?: ConfirmSuccessfulSignInParams) {
-    const email = params?.email ?? DEFAULT_DUMMY_EMAIL;
+    const email = this.email(params?.email ?? DEFAULT_DUMMY_EMAIL);
     await this.driver.confirmSuccessfulSignIn(email);
   }
 

--- a/acceptance/dsl/SurveyExecutionDsl.ts
+++ b/acceptance/dsl/SurveyExecutionDsl.ts
@@ -1,4 +1,5 @@
 import { ProtocolDriver } from '../drivers/ProtocolDriver.ts';
+import { namespaceName } from './testNamespace.ts';
 
 export type CreateSurveyRunParams = {
   teamName: string;
@@ -92,12 +93,19 @@ const DEFAULT_SURVEY_RUN_TITLE = 'Survey 1';
 const DEFAULT_SURVEY_RUN_ANSWERS = [1, 2, 3, 4, 5, 4, 3, 2, 1, 2];
 
 export class SurveyExecutionDsl {
-  constructor(private readonly driver: ProtocolDriver) {
+  constructor(
+    private readonly driver: ProtocolDriver,
+    private readonly token: string,
+  ) {
+  }
+
+  private name(name: string): string {
+    return namespaceName(name, this.token);
   }
 
   async createSurveyRun(params: CreateSurveyRunParams) {
-    const title = params.title ?? DEFAULT_SURVEY_RUN_TITLE;
-    await this.driver.createSurveyRun(params.teamName, title);
+    const title = this.name(params.title ?? DEFAULT_SURVEY_RUN_TITLE);
+    await this.driver.createSurveyRun(this.name(params.teamName), title);
   }
 
   async confirmCreatingSurveyRunNotPossible() {
@@ -105,13 +113,13 @@ export class SurveyExecutionDsl {
   }
 
   async confirmSurveyRunIsListed(params: ConfirmSurveyRunIsListedParams) {
-    const title = params.title ?? DEFAULT_SURVEY_RUN_TITLE;
-    await this.driver.confirmSurveyRunIsListed(params.teamName, title);
+    const title = this.name(params.title ?? DEFAULT_SURVEY_RUN_TITLE);
+    await this.driver.confirmSurveyRunIsListed(this.name(params.teamName), title);
   }
 
   async openSurveyRunPage(params: OpenSurveyRunPageParams) {
-    const title = params.title ?? DEFAULT_SURVEY_RUN_TITLE;
-    await this.driver.openSurveyRunPage(params.teamName, title);
+    const title = this.name(params.title ?? DEFAULT_SURVEY_RUN_TITLE);
+    await this.driver.openSurveyRunPage(this.name(params.teamName), title);
   }
 
   async confirmSurveyRunCount(params: ConfirmSurveyRunCountParams) {
@@ -124,13 +132,13 @@ export class SurveyExecutionDsl {
   }
 
   async openSurveyRun(params: OpenSurveyRunParams) {
-    const title = params.title ?? DEFAULT_SURVEY_RUN_TITLE;
-    await this.driver.openSurveyRun(params.teamName, title);
+    const title = this.name(params.title ?? DEFAULT_SURVEY_RUN_TITLE);
+    await this.driver.openSurveyRun(this.name(params.teamName), title);
   }
 
   async confirmAcceptsSurveyResponse(params: ConfirmAcceptsSurveyResponse) {
-    const title = params.title ?? DEFAULT_SURVEY_RUN_TITLE;
-    await this.driver.openSurveyRunPage(params.teamName, title);
+    const title = this.name(params.title ?? DEFAULT_SURVEY_RUN_TITLE);
+    await this.driver.openSurveyRunPage(this.name(params.teamName), title);
     await this.driver.confirmAcceptsSurveyResponse();
   }
 
@@ -144,9 +152,9 @@ export class SurveyExecutionDsl {
   }
 
   async confirmResponseSaved(params: ConfirmResponseSavedParams) {
-    const title = params.surveyTitle ?? DEFAULT_SURVEY_RUN_TITLE;
+    const title = this.name(params.surveyTitle ?? DEFAULT_SURVEY_RUN_TITLE);
     const answers = params.answers ?? DEFAULT_SURVEY_RUN_ANSWERS;
-    await this.driver.confirmResponseSaved(params.teamName, title, answers);
+    await this.driver.confirmResponseSaved(this.name(params.teamName), title, answers);
   }
 
   async confirmAllQuestionsHave5PointScale() {
@@ -168,13 +176,13 @@ export class SurveyExecutionDsl {
   // Assessment Results
 
   async closeSurveyRun(params: CloseSurveyRunParams) {
-    const title = params.title ?? DEFAULT_SURVEY_RUN_TITLE;
-    await this.driver.closeSurveyRun(params.teamName, title);
+    const title = this.name(params.title ?? DEFAULT_SURVEY_RUN_TITLE);
+    await this.driver.closeSurveyRun(this.name(params.teamName), title);
   }
 
   async reopenSurveyRun(params: ReopenSurveyRunParams) {
-    const title = params.title ?? DEFAULT_SURVEY_RUN_TITLE;
-    await this.driver.reopenSurveyRun(params.teamName, title);
+    const title = this.name(params.title ?? DEFAULT_SURVEY_RUN_TITLE);
+    await this.driver.reopenSurveyRun(this.name(params.teamName), title);
   }
 
   async confirmReopeningSurveyRunIsNotPossible() {
@@ -182,8 +190,8 @@ export class SurveyExecutionDsl {
   }
 
   async viewAssessmentResults(params: ViewAssessmentResultsParams) {
-    const title = params.surveyTitle ?? DEFAULT_SURVEY_RUN_TITLE;
-    await this.driver.openSurveyRunPage(params.teamName, title);
+    const title = this.name(params.surveyTitle ?? DEFAULT_SURVEY_RUN_TITLE);
+    await this.driver.openSurveyRunPage(this.name(params.teamName), title);
   }
 
   async confirmAssessmentResultsDisplayed() {
@@ -236,8 +244,8 @@ export class SurveyExecutionDsl {
   // Capability Profile
 
   async viewCapabilityProfile(params: ViewCapabilityProfileParams) {
-    const title = params.surveyTitle ?? DEFAULT_SURVEY_RUN_TITLE;
-    await this.driver.openSurveyRunPage(params.teamName, title);
+    const title = this.name(params.surveyTitle ?? DEFAULT_SURVEY_RUN_TITLE);
+    await this.driver.openSurveyRunPage(this.name(params.teamName), title);
   }
 
   async confirmCapabilityProfileVisualizationDisplayed() {
@@ -263,7 +271,7 @@ export class SurveyExecutionDsl {
   // Trend View
 
   async viewTrendView(params: { teamName: string }) {
-    await this.driver.openTrendView(params.teamName);
+    await this.driver.openTrendView(this.name(params.teamName));
   }
 
   async confirmTrendVisualizationDisplayed() {
@@ -275,7 +283,9 @@ export class SurveyExecutionDsl {
   }
 
   async confirmRunsInChronologicalOrder(params: { expectedTitlesInOrder: string[] }) {
-    await this.driver.confirmRunsInChronologicalOrder(params.expectedTitlesInOrder);
+    await this.driver.confirmRunsInChronologicalOrder(
+      params.expectedTitlesInOrder.map((title) => this.name(title)),
+    );
   }
 
   async confirmDoraCapabilityImproved(params: {
@@ -285,8 +295,8 @@ export class SurveyExecutionDsl {
   }) {
     await this.driver.confirmDoraCapabilityImproved(
       params.doraCapabilityName,
-      params.fromRunTitle,
-      params.toRunTitle,
+      this.name(params.fromRunTitle),
+      this.name(params.toRunTitle),
     );
   }
 
@@ -297,8 +307,8 @@ export class SurveyExecutionDsl {
   }) {
     await this.driver.confirmDoraCapabilityDeclined(
       params.doraCapabilityName,
-      params.fromRunTitle,
-      params.toRunTitle,
+      this.name(params.fromRunTitle),
+      this.name(params.toRunTitle),
     );
   }
 
@@ -309,8 +319,8 @@ export class SurveyExecutionDsl {
   }) {
     await this.driver.confirmDoraCapabilityRemainedUnchanged(
       params.doraCapabilityName,
-      params.fromRunTitle,
-      params.toRunTitle,
+      this.name(params.fromRunTitle),
+      this.name(params.toRunTitle),
     );
   }
 

--- a/acceptance/dsl/TeamManagementDsl.ts
+++ b/acceptance/dsl/TeamManagementDsl.ts
@@ -1,4 +1,5 @@
 import { ProtocolDriver } from '../drivers/ProtocolDriver.ts';
+import { namespaceEmail, namespaceName } from './testNamespace.ts';
 
 export type CreateTeamParams = {
   name?: string;
@@ -87,28 +88,39 @@ const DEFAULT_DUMMY_TEAM_NAME = 'Road Runners';
 const DEFAULT_DUMMY_TEAM_DESCRIPTION = 'The best team in the world!';
 
 export class TeamManagementDsl {
-  constructor(private readonly driver: ProtocolDriver) {
+  constructor(
+    private readonly driver: ProtocolDriver,
+    private readonly token: string,
+  ) {
+  }
+
+  private name(name: string): string {
+    return namespaceName(name, this.token);
+  }
+
+  private email(email: string): string {
+    return namespaceEmail(email, this.token);
   }
 
   async createTeam(params?: CreateTeamParams) {
-    const name = params?.name ?? DEFAULT_DUMMY_TEAM_NAME;
+    const name = this.name(params?.name ?? DEFAULT_DUMMY_TEAM_NAME);
     const description = params?.description ?? DEFAULT_DUMMY_TEAM_DESCRIPTION;
     await this.driver.createTeam(name, description);
   }
 
   async confirmTeamCreated(params?: ConfirmTeamCreatedParams) {
-    const teamName = params?.name ?? DEFAULT_DUMMY_TEAM_NAME;
+    const teamName = this.name(params?.name ?? DEFAULT_DUMMY_TEAM_NAME);
     await this.driver.confirmTeamCreated(teamName);
   }
 
   async confirmTeamLead(params: ConfirmTeamLeadParams) {
-    const teamName = params.teamName ?? DEFAULT_DUMMY_TEAM_NAME;
-    await this.driver.confirmTeamLead(teamName, params.email);
+    const teamName = this.name(params.teamName ?? DEFAULT_DUMMY_TEAM_NAME);
+    await this.driver.confirmTeamLead(teamName, this.email(params.email));
   }
 
   async addTeamMember(params: AddTeamMemberParams) {
-    const teamName = params.teamName ?? DEFAULT_DUMMY_TEAM_NAME;
-    await this.driver.addTeamMember(teamName, params.email);
+    const teamName = this.name(params.teamName ?? DEFAULT_DUMMY_TEAM_NAME);
+    await this.driver.addTeamMember(teamName, this.email(params.email));
   }
 
   async openHomePage() {
@@ -116,33 +128,33 @@ export class TeamManagementDsl {
   }
 
   async openTeamMembers(params?: OpenTeamMembersParams) {
-    const teamName = params?.teamName ?? DEFAULT_DUMMY_TEAM_NAME;
+    const teamName = this.name(params?.teamName ?? DEFAULT_DUMMY_TEAM_NAME);
     await this.driver.openTeamMembers(teamName);
   }
 
   async confirmTeamInList(params?: ConfirmTeamInListParams) {
-    const teamName = params?.teamName ?? DEFAULT_DUMMY_TEAM_NAME;
+    const teamName = this.name(params?.teamName ?? DEFAULT_DUMMY_TEAM_NAME);
     await this.driver.confirmTeamInList(teamName);
   }
 
   async openTeamDetails(params?: OpenTeamDetailsParams) {
-    const teamName = params?.teamName ?? DEFAULT_DUMMY_TEAM_NAME;
+    const teamName = this.name(params?.teamName ?? DEFAULT_DUMMY_TEAM_NAME);
     await this.driver.openTeamDetails(teamName);
   }
 
   async confirmTeamDetails(params: ConfirmTeamDetailsParams) {
-    const teamName = params.teamName ?? DEFAULT_DUMMY_TEAM_NAME;
+    const teamName = this.name(params.teamName ?? DEFAULT_DUMMY_TEAM_NAME);
     const description = params.description ?? DEFAULT_DUMMY_TEAM_DESCRIPTION;
     const numberOfSurveyRuns = params.numberOfSurveyRuns ?? 0;
     await this.driver.confirmTeamDetails(teamName, description, numberOfSurveyRuns);
   }
 
   async confirmTeamMemberInList(params: ConfirmTeamMemberInListParams) {
-    await this.driver.confirmTeamMemberInList(params.email);
+    await this.driver.confirmTeamMemberInList(this.email(params.email));
   }
 
   async confirmTeamLeadInList(params: ConfirmTeamLeadInListParams) {
-    await this.driver.confirmTeamLeadInList(params.email);
+    await this.driver.confirmTeamLeadInList(this.email(params.email));
   }
 
   async attemptOpenTeamDetails() {
@@ -154,9 +166,9 @@ export class TeamManagementDsl {
   }
 
   async editTeamDetails(params: EditTeamDetailsParams) {
-    const teamName = params.teamName ?? DEFAULT_DUMMY_TEAM_NAME;
+    const teamName = this.name(params.teamName ?? DEFAULT_DUMMY_TEAM_NAME);
     await this.driver.openEditTeamPage(teamName);
-    await this.driver.editTeamDetails(params.newName, params.newDescription);
+    await this.driver.editTeamDetails(this.name(params.newName), params.newDescription);
   }
 
   async confirmEditButtonNotVisible() {
@@ -172,16 +184,16 @@ export class TeamManagementDsl {
   }
 
   async removeTeamMember(params: RemoveTeamMemberParams) {
-    const teamName = params.teamName ?? DEFAULT_DUMMY_TEAM_NAME;
-    await this.driver.removeTeamMember(teamName, params.email);
+    const teamName = this.name(params.teamName ?? DEFAULT_DUMMY_TEAM_NAME);
+    await this.driver.removeTeamMember(teamName, this.email(params.email));
   }
 
   async confirmTeamMemberNotInList(params: ConfirmTeamMemberInListParams) {
-    await this.driver.confirmTeamMemberNotInList(params.email);
+    await this.driver.confirmTeamMemberNotInList(this.email(params.email));
   }
 
   async confirmTeamNotInList(params?: ConfirmTeamNotInListParams) {
-    const teamName = params?.teamName ?? DEFAULT_DUMMY_TEAM_NAME;
+    const teamName = this.name(params?.teamName ?? DEFAULT_DUMMY_TEAM_NAME);
     await this.driver.confirmTeamNotInList(teamName);
   }
 
@@ -194,13 +206,13 @@ export class TeamManagementDsl {
   }
 
   async promoteMemberToTeamLead(params: PromoteMemberToTeamLeadParams) {
-    const teamName = params.teamName ?? DEFAULT_DUMMY_TEAM_NAME;
-    await this.driver.promoteMemberToTeamLead(teamName, params.email);
+    const teamName = this.name(params.teamName ?? DEFAULT_DUMMY_TEAM_NAME);
+    await this.driver.promoteMemberToTeamLead(teamName, this.email(params.email));
   }
 
   async demoteTeamLeadToMember(params: DemoteTeamLeadToMemberParams) {
-    const teamName = params.teamName ?? DEFAULT_DUMMY_TEAM_NAME;
-    await this.driver.demoteTeamLeadToMember(teamName, params.email);
+    const teamName = this.name(params.teamName ?? DEFAULT_DUMMY_TEAM_NAME);
+    await this.driver.demoteTeamLeadToMember(teamName, this.email(params.email));
   }
 
   async confirmChangeRoleErrorMessage(params: ConfirmChangeRoleErrorMessageParams) {

--- a/acceptance/dsl/testNamespace.ts
+++ b/acceptance/dsl/testNamespace.ts
@@ -1,0 +1,11 @@
+export function namespaceEmail(email: string, token: string): string {
+  const atIndex = email.indexOf('@');
+  if (atIndex === -1) return email;
+  const local = email.slice(0, atIndex);
+  const domain = email.slice(atIndex + 1);
+  return `${local}+${token}@${domain}`;
+}
+
+export function namespaceName(name: string, token: string): string {
+  return `${name} ${token}`;
+}

--- a/acceptance/runAllSuites.ts
+++ b/acceptance/runAllSuites.ts
@@ -21,6 +21,7 @@ async function main() {
         'test',
         '--permit-no-files',
         '--allow-all',
+        '--parallel',
         '--junit-path=./acceptance-tests-report.xml',
         'acceptance/tests/*.spec.ts',
       ],
@@ -29,6 +30,7 @@ async function main() {
       stderr: 'inherit',
       env: {
         ...Deno.env.toObject(),
+        DENO_JOBS: Deno.env.get('DENO_JOBS') || '4',
         ACCEPTANCE_SUT_MANAGED: 'true',
         ACCEPTANCE_SUT_BASE_URL: astroSut.baseUrl,
         DATABASE_URL: databaseUrl,

--- a/acceptance/sut/authDatabaseSut.ts
+++ b/acceptance/sut/authDatabaseSut.ts
@@ -1,12 +1,4 @@
-import postgres from 'postgres';
 import { runMigrations } from '../../deno_scripts/db/migrate.ts';
-
-const RESET_SCRIPT = `
-  DELETE FROM auth_verification;
-  DELETE FROM auth_account;
-  DELETE FROM auth_session;
-  DELETE FROM auth_user;
-`;
 
 export class AuthTestDatabase {
   private databaseUrl: string | null = null;
@@ -14,24 +6,5 @@ export class AuthTestDatabase {
   async runMigrations(databaseUrl: string): Promise<void> {
     this.databaseUrl = databaseUrl;
     await runMigrations(databaseUrl, './db/migrations_better-auth', '_migrations_auth');
-  }
-
-  async resetData(): Promise<void> {
-    if (!this.databaseUrl) {
-      throw new Error('Auth database not set up. Call runMigrations() first.');
-    }
-
-    const sql = postgres(this.databaseUrl);
-    try {
-      await sql.unsafe(RESET_SCRIPT);
-    } finally {
-      await sql.end();
-    }
-  }
-
-  static connectToExisting(databaseUrl: string): AuthTestDatabase {
-    const instance = new AuthTestDatabase();
-    instance.databaseUrl = databaseUrl;
-    return instance;
   }
 }

--- a/acceptance/sut/databaseSut.ts
+++ b/acceptance/sut/databaseSut.ts
@@ -2,14 +2,6 @@ import postgres from 'postgres';
 import { runMigrations } from '../../deno_scripts/db/migrate.ts';
 import { seedDoraCapabilities } from '../../deno_scripts/db/seed_dora_capabilities.ts';
 
-const RESET_SCRIPT = `
-  DELETE FROM survey_responses;
-  DELETE FROM survey_runs;
-  DELETE FROM team_memberships;
-  DELETE FROM teams;
-  DELETE FROM users;
-`;
-
 interface TestDbContext {
   databaseUrl: string;
   dbName: string;
@@ -53,26 +45,6 @@ export class TestDatabase {
     const databaseUrl = getDatabaseUrlOrExit();
     await dropDatabase(databaseUrl, this.context.dbName).catch(() => {});
     this.context = null;
-  }
-
-  async resetData(): Promise<void> {
-    if (!this.context) {
-      throw new Error('Test database not set up. Call setUp() first.');
-    }
-
-    const sql = postgres(this.context.databaseUrl);
-    try {
-      await sql.unsafe(RESET_SCRIPT);
-    } finally {
-      await sql.end();
-    }
-  }
-
-  static connectToExisting(databaseUrl: string): TestDatabase {
-    const instance = new TestDatabase();
-    const url = new URL(databaseUrl);
-    instance.context = { databaseUrl, dbName: url.pathname.slice(1) };
-    return instance;
   }
 }
 

--- a/acceptance/tests/testSetup.ts
+++ b/acceptance/tests/testSetup.ts
@@ -7,7 +7,7 @@ import { AuthTestDatabase } from '../sut/authDatabaseSut.ts';
 const isManagedMode = Deno.env.get('ACCEPTANCE_SUT_MANAGED') === 'true';
 
 function generateTestToken(): string {
-  return crypto.randomUUID().replaceAll('-', '').slice(0, 8);
+  return crypto.randomUUID().replaceAll('-', '');
 }
 
 export function setupAcceptanceTest(): Dsl {

--- a/acceptance/tests/testSetup.ts
+++ b/acceptance/tests/testSetup.ts
@@ -6,6 +6,10 @@ import { AuthTestDatabase } from '../sut/authDatabaseSut.ts';
 
 const isManagedMode = Deno.env.get('ACCEPTANCE_SUT_MANAGED') === 'true';
 
+function generateTestToken(): string {
+  return crypto.randomUUID().replaceAll('-', '').slice(0, 8);
+}
+
 export function setupAcceptanceTest(): Dsl {
   const dsl = new Dsl();
 
@@ -19,8 +23,6 @@ function setupManagedMode(dsl: Dsl): Dsl {
   const baseUrl = Deno.env.get('ACCEPTANCE_SUT_BASE_URL')!;
   const databaseUrl = Deno.env.get('DATABASE_URL')!;
 
-  const databaseSut = TestDatabase.connectToExisting(databaseUrl);
-  const authDatabaseSut = AuthTestDatabase.connectToExisting(databaseUrl);
   const astroSut: AstroSutHandle = {
     baseUrl,
     ownsProcess: false,
@@ -37,9 +39,7 @@ function setupManagedMode(dsl: Dsl): Dsl {
   });
 
   beforeEach(async () => {
-    await databaseSut.resetData();
-    await authDatabaseSut.resetData();
-    await dsl.setUp(astroSut);
+    await dsl.setUp(astroSut, generateTestToken());
   });
 
   afterEach(async () => {
@@ -70,9 +70,7 @@ function setupStandaloneMode(dsl: Dsl): Dsl {
   });
 
   beforeEach(async () => {
-    await databaseSut.resetData();
-    await authDatabaseSut.resetData();
-    await dsl.setUp(astroSut);
+    await dsl.setUp(astroSut, generateTestToken());
   });
 
   afterEach(async () => {

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -13,6 +13,8 @@
 deno task test:acceptance
 ```
 
+**Parallel execution:** Specs run in parallel against one shared DB with no per-test reset. Each test gets a unique token; the DSL namespaces every email/team/survey identifier with it. Write plain literals and route all identifiers through the DSL.
+
 **Run single spec:**
 ```bash
 deno test --env-file=.env.acceptance --allow-all acceptance/tests/0001-001-user-registration.spec.ts


### PR DESCRIPTION
Replace per-test DB resets with unique token-per-test data isolation, allowing specs to run in parallel against a shared DB without conflicts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Acceptance tests now run in parallel and use per-test unique tokens for isolation.

* **Refactor**
  * Test setup switched from per-test DB resets to token-based namespacing of identifiers (emails, team/survey names).
  * Removed test database/auth reset utilities from the test infrastructure.

* **Documentation**
  * Testing guidance updated to cover parallel execution and token-based identifier namespacing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JensWinter/mse-radar/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->